### PR TITLE
Add IoStore information to existing & new guides + repak as an alternative to UnrealPak

### DIFF
--- a/BasicModding/IoStorePacking.md
+++ b/BasicModding/IoStorePacking.md
@@ -1,0 +1,40 @@
+# IoStore Packing
+
+> [!IMPORTANT]
+> This guide only applies when there are `.ucas`, `.utoc` & `.pak` files inside `Content/Paks` folder.
+
+There are three scenarios when you need to pack IoStore assets, and the methods differ depending on them:
+1. You have hex edited cooked assets extracted from [ZenTools](../TheBasics/ExtractingIoStore.md) with [UAssetGUI](UAssetGUI.md) or similar
+2. You have a UE project and have created assets within it
+3. You have extracted IoStore Zen assets from [FModel](../TheBasics/ExportingFModel.md) and wish to repack them
+
+## Scenario 1: Packing cooked assets
+
+### For UE5
+
+Download this tool called [IoStorePackager](https://github.com/Buckminsterfullerene02/UE-Modding-Tools/blob/main/Loose%20Files/IOStorePackagev2.zip). It is a very simple GUI commandlet where you input file paths following the examples, and it calls UnrealPak from the Unreal Engine version you have installed with all the right arguments. 
+
+You can watch [this video](https://www.youtube.com/watch?v=89s0akNvpU4) that guides you how to use `IoStorePackager`:
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/89s0akNvpU4?si=rMpESKZKsplRrqCn" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+### For UE4
+
+Use this [IoStorePackager-UE4](https://gist.github.com/Buckminsterfullerene02/0f7233d5dda97c82039ba932c2bc8fb7). Similar to above, but you also need a C++ template project for the game, as `ZenTools-UE4` does not output the same manifest files as `ZenTools` that UE needs to create the container files.
+
+Video guide coming soon hopefully.
+
+## Scenario 2: UE project packing
+
+If you have made mod content inside of the editor, you'll need to cook and pack it through the editor. Luckily, this is really simple. 
+
+Inside the editor, go to `Edit -> Project settings -> Packaging`, then make sure `Use Io Store` at the top of the packaging settings is checked.
+
+Then, follow the [cooking content](../IntermediateModding/CookingContent.md) guide as normal.
+
+## Scenario 3: Packing FModel Zen .uassets
+
+Use the tool [UnrealReZen](https://github.com/rm-NoobInCoding/UnrealReZen). The instructions are quite straight-forward, but be warned, that there is no alternative tool to UnrealReZen for packing FModel Zen `.uassets`.
+
+> [!CAUTION]
+> This tool does not support extracting assets from ZenTools extracted files.

--- a/BasicModding/UAssetGUI.md
+++ b/BasicModding/UAssetGUI.md
@@ -1,6 +1,8 @@
 # Using UAssetGUI
 UAssetGUI is a user-interfaced tool for essentially hex editing but without seeing any hex.
 
+You can download the latest release of UAssetGUI [here](https://github.com/atenfyr/UAssetGUI/releases).
+
 ## Example - Changing clip size for Trepang2
 For this example, we will change the magazine size for the SMG weapon, which is located inside the weapon's blueprint called `BP_SMG`.
 

--- a/BasicModding/UnrealPak.md
+++ b/BasicModding/UnrealPak.md
@@ -1,17 +1,35 @@
 # Creating Pak Files
+> [!IMPORTANT]
+> This only guide applies when there are NOT `.ucas` or `.utoc` files inside `Content/Paks` folder. There may be `.pak`, `.sig` or other files or folders.   
+
 To ensure your mod is loaded by the game, it needs to be in a `.pak` file.
 
-To get UnrealPak scripts, download it from [UnrealPak](https://github.com/Dmgvol/UE_Modding/raw/main/Tools/UnrealPak.zip)
+## Packer methods
 
-## UnrealPak Folder
+There are two ways you can pack your mod files into a `.pak` file:
+1. UnrealPak - a commandlet within UE
+2. repak - a third party commandlet
+
+UnrealPak and repak are fine to use with any UE version. repak is generally faster and has more advanced features like configurable mount points & pak version, but is not required for the majority of users, and overall ease of use is slightly more difficult than the below UnrealPak scripts. But if one doesn't work for you, you at least can try the other. 
+
+UnrealPak is present in every UE install, but can be extracted into a standalone program. You can download the standalone version from [here](https://github.com/Dmgvol/UE_Modding/raw/main/Tools/UnrealPak.zip), which also comes with a couple of batch scripts to make calling the program easier for you.
+
+*You can also install [repak_wrappers](https://github.com/Mythical-Github/repak_wrappers/archive/refs/heads/main.zip), which has an identical user experience to UnrealPak. If you download this, you can follow the "If using UnrealPak" parts of the guide.*
+
+**If using UnrealPak:**
+
 Create a folder that will contain the scripts, raw mod folder and output pak files, similar to this:
 
 ![](/Media/UnrealPak/unrealpak1.png)
 
 _(Extract the provided UnrealPak zip file)_
 
+**If using repak:** 
+
+Follow the installation and usage instructions in the [Extracting cooked with repak](../TheBasics/ExtractingCooked.md#installation) guide.
+
 ## Mod Folder
-For every mod, a mod folder with the exact folder structure is required.
+For every mod, regardless of the packing tool, a mod folder with the exact folder structure is required.
 
 ```
 Modname_P\GameName\Content\...
@@ -53,14 +71,25 @@ The content of the following folder is:
 
 <hr>
 
-## Using the Script
+## Using the tool
+**If using UnrealPak:**
+
 Simple, just drag the mod folder onto the `UnrealPak-With-compression.bat` to begin packaging the mod folder. <br>
 Shortly after, a pak file with the same name will be created.
 
 ![](/Media/UnrealPak/unrealpak3.png)
 
+**If using repak:**
 
-## Adding mods to the Game
+Simply run the command `repak pack <mod directory to pack>` inside the directory containing your mod folder. 
+
+If you wish to see the file paths it is packing, use the `-v` option.
+
+If you wish to use compression, add the `--compression <method>` option. You can see supported compression formats with `repak pack -h`. `gzip`, `zlib` and `zstd` formats are recommended. If the game fails to load the pak file, one of the things to try is to pack without compression.
+
+E.g. `repak pack -v --compression Gzip Modname_P`
+
+## Adding mods to the game
 1. Navigate to the Paks folder of the game.
 
 Usually it's following this pattern:

--- a/BasicModding/UnrealPak.md
+++ b/BasicModding/UnrealPak.md
@@ -1,5 +1,5 @@
 # Creating Pak Files
-To ensure your mod is loaded by the game, it needs to be in a `.pak` file, and if our game has IOStore enabled then 3 files; `.pak`, `.utoc`, and `.ucas`.
+To ensure your mod is loaded by the game, it needs to be in a `.pak` file.
 
 To get UnrealPak scripts, download it from [UnrealPak](https://github.com/Dmgvol/UE_Modding/raw/main/Tools/UnrealPak.zip)
 

--- a/IntermediateModding/CookingContent.md
+++ b/IntermediateModding/CookingContent.md
@@ -8,8 +8,11 @@ __For UE4__
 __For UE5__
 - Navigate to [Cooking UE5](#cooking-ue5) <br>
 
+> [!IMPORTANT]  
+> For `IoStore` games, first navigate to Edit -> Project settings -> Packaging, then make sure `Use Io Store` at the top of the packaging settings is checked. Then follow the rest of this guide as normal.
 
-# Cooking UE4 (UnrealPak Route)
+
+## Cooking UE4 (UnrealPak Route)
 Once you're ready, click File -> Cook Content for Windows.
 
 ![](/Media/Compiling/ue4_1.png)
@@ -24,7 +27,7 @@ From here, you will have to use UnrealPak which you can learn more about packagi
 <br>
 Based on which assets you've created, you will need to copy-paste them into the mod folder (covered in unrealPak guide). 
 
-# Cooking UE4 (Generating-Chunks Route)
+## Cooking UE4 (Generating-Chunks Route)
 Another method of cooking UE content is by packaging specific assets into predefined chunks.<br>
 it's faster as there is no need for UnrealPak but It's limited as it packs only what's in the editor. <br>
 Meaning it's not suitable if you want to combine modified assets or precooked assets into that mod.
@@ -38,7 +41,7 @@ File -> Package Project -> Windows
 
 <hr>
 
-# Cooking UE5
+## Cooking UE5
 For UE5, modders have to assign their assets to specific chunk ids, and there are 2 methods to do so, which will be covered below.
 
 The two methods are [Manual Chunks](#manual-chunk-ids) and [BulkChunk](#bulk-assign-using-datatabledt). <br>

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Just so you get the idea and the principles of UE4/5 modding and how it works.
 We will start with how we can browse and export game files.
 
 - [Finding AES key (.pak encryption)](./TheBasics/AesKey.md)
+- [Extracting Cooked Assets](./TheBasics/ExtractingCooked.md) (`.pak` only)
+- [Extracting IoStore Cooked Assets](./TheBasics/ExtractingIoStore.md) (`.pak`/`.utoc`/`.ucas`)
 - [Exporting - FModel](./TheBasics/ExportingFModel.md)
 - [Exporting - UModel](./TheBasics/ExportingUModel.md)
 - [Previewing Animations - UModel](./TheBasics/UModelAnimations.md)
@@ -30,11 +32,13 @@ We will start with how we can browse and export game files.
 ## Basic Modding
 Let's start changing values!</br>
 This is essential to <b>ANY</b> value changing.</br>
-- [Editing UAsset values - UAssetGUI](./BasicModding/UAssetGUI.md) (UE4)
-- [Editing UAsset values - Hex](./BasicModding/HexEditing.md) _(Manual _hex, _in case_ UAssetGUI fails_)_
-- [Editing UMaps - stove](./BasicModding/EditingUmaps.md) (UE4)
-- [Disabling/Removing textures of objects](./BasicModding/DisablingObjects.md) (UE4)
-- [Creating Pak Files - UnrealPak](./BasicModding/UnrealPak.md) (UE4)
+- [Editing UAsset values - UAssetGUI](./BasicModding/UAssetGUI.md)
+- [Editing UAsset values - Hex](./BasicModding/HexEditing.md) *(Manual hex, in case UAssetGUI fails)*
+- [Editing UMaps - stove](./BasicModding/EditingUmaps.md) (UE4, `.pak` only)
+- [Disabling/Removing textures of objects](./BasicModding/DisablingObjects.md)
+- [Creating Pak Files - UnrealPak](./BasicModding/UnrealPak.md) (UE4, `.pak` only)
+- [Creating Pak Files - Repak](./BasicModding/) (UE4/UE5, `.pak` only)
+- [Creating Pak Files - IoStore](./BasicModding/IoStorePacking.md) (UE4/UE5, `.pak`/`.utoc`/`.ucas`)
 - [Mod example - modifying Blueprint default values](./BasicModding/example1.md) (UE4)
 
 ## Intermediate Modding

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Just so you get the idea and the principles of UE4/5 modding and how it works.
 We will start with how we can browse and export game files.
 
 - [Finding AES key (.pak encryption)](./TheBasics/AesKey.md)
-- [Extracting Cooked Assets](./TheBasics/ExtractingCooked.md) (`.pak` only)
-- [Extracting IoStore Cooked Assets](./TheBasics/ExtractingIoStore.md) (`.pak`/`.utoc`/`.ucas`)
+- [Extracting Cooked Assets - repak](./TheBasics/ExtractingCooked.md) (`.pak` only)
+- [Extracting IoStore Cooked Assets - ZenTools](./TheBasics/ExtractingIoStore.md) (`.pak`/`.utoc`/`.ucas`)
 - [Exporting - FModel](./TheBasics/ExportingFModel.md)
 - [Exporting - UModel](./TheBasics/ExportingUModel.md)
 - [Previewing Animations - UModel](./TheBasics/UModelAnimations.md)
@@ -36,9 +36,8 @@ This is essential to <b>ANY</b> value changing.</br>
 - [Editing UAsset values - Hex](./BasicModding/HexEditing.md) *(Manual hex, in case UAssetGUI fails)*
 - [Editing UMaps - stove](./BasicModding/EditingUmaps.md) (UE4, `.pak` only)
 - [Disabling/Removing textures of objects](./BasicModding/DisablingObjects.md)
-- [Creating Pak Files - UnrealPak](./BasicModding/UnrealPak.md) (UE4, `.pak` only)
-- [Creating Pak Files - Repak](./BasicModding/) (UE4/UE5, `.pak` only)
-- [Creating Pak Files - IoStore](./BasicModding/IoStorePacking.md) (UE4/UE5, `.pak`/`.utoc`/`.ucas`)
+- [Creating Pak Files](./BasicModding/UnrealPak.md) (`.pak` only)
+- [Creating Pak Files - IoStore](./BasicModding/IoStorePacking.md) (`.pak`/`.utoc`/`.ucas`)
 - [Mod example - modifying Blueprint default values](./BasicModding/example1.md) (UE4)
 
 ## Intermediate Modding

--- a/TheBasics/ExportingFModel.md
+++ b/TheBasics/ExportingFModel.md
@@ -4,6 +4,9 @@ FModel is one of the best tools to browse, view and export all of the file types
 If your game has AES: [Adding AES](#adding-aes-key-optional).<br>
 If your game has usmapping: [Adding mappings](#adding-usmapping-optional) _(mostly UE5+)_.
 
+> [!CAUTION]
+> Exported FModel assets are in a format that only allows them to be read-only. This means that these assets cannot be edited in a valid way for modding (e.g. with [UAssetGUI](../BasicModding/UAssetGUI.md)), nor can they be repackaged.
+
 # Creating Game Preset
 Launch the tool, Directory -> Selector.
 

--- a/TheBasics/ExportingFModel.md
+++ b/TheBasics/ExportingFModel.md
@@ -4,9 +4,6 @@ FModel is one of the best tools to browse, view and export all of the file types
 If your game has AES: [Adding AES](#adding-aes-key-optional).<br>
 If your game has usmapping: [Adding mappings](#adding-usmapping-optional) _(mostly UE5+)_.
 
-> [!CAUTION]
-> Exported FModel assets are in a format that only allows them to be read-only. This means that these assets cannot be edited in a valid way for modding (e.g. with [UAssetGUI](../BasicModding/UAssetGUI.md)), nor can they be repackaged.
-
 # Creating Game Preset
 Launch the tool, Directory -> Selector.
 
@@ -56,7 +53,7 @@ Exporting is simple, just right-click on the file(s) you want, and pick the righ
 <br>
 Different asset types can be exported differently.<br>
 
--   `.uasset` such as blueprints, DataTables, Structs - export directly or Json (read-only).
+- Zen `.uasset` such as blueprints, DataTables, Structs - export directly or Json **(Zen assets are incompatible with UAssetGUI, you can only edit with [hex editing](../BasicModding/HexEditing.md))**.
 - Textures - as `.png`.
 - Models such as StaticMesh or SkeletalMesh (characters) - `.psk`
 - Animations - `.psa`
@@ -66,3 +63,4 @@ It doesn't have to be as exact, it really depends on the case and mod.
 <br>
 For example: exporting a skeletal mesh as `.uasset` to edit the used textures by changing the paths.
 
+To repack a Zen uasset exported by FModel, you can use [UnrealReZen](../BasicModding/IoStorePacking.md).

--- a/TheBasics/ExtractingCooked.md
+++ b/TheBasics/ExtractingCooked.md
@@ -1,0 +1,66 @@
+# Extracting Cooked Assets
+> [!IMPORTANT]
+> This only guide applies when there are NOT `.ucas` or `.utoc` files inside `Content/Paks` folder. There may be `.pak`, `.sig` or other files or folders.   
+
+## Repak
+
+For this guide, we will be using [repak](https://github.com/trumank/repak). This tool is widely used as it:
+1. Is very easy to download and use
+2. Has very good support of all UE4 and UE5 versions
+3. Is actively maintained
+4. Is faster than alternatives
+5. Is cross-platform
+6. Has some useful utilities built-in (but we will be using its most basic functionalities)
+7. Guards against malicious pak files that attempt to write to parent directories
+
+### Installation
+
+To install repak, simply head to the [releases page](https://github.com/trumank/repak/releases) and download the latest release. For windows users, you can download the `repak_cli-x86_64-pc-windows-msvc.msi` to have it installed into your PATH automatically, which allows you to call the `repak` utility from anywhere in your system.
+
+If you choose the installer (`.msi`) and double click it to install repak, Windows will likely:
+1. Ask if you want to run it. Click yes
+2. Show a defender popup saying you shouldn't run this file. Click "More" then "Run anyway". This popup shows because the repak installer is not signed, which costs over $100/year
+
+If you don't feel comfortable running the installer on your computer, you can simply download the `.zip` version of repak and then in the below usage commands, you can reference to wherever you have the repak.exe (with absolute/relative paths or by adding it to your `PATH` manually).
+
+### Usage
+
+> [!WARNING]
+> Do not run `repak.exe` by clicking on it, it is not meant to be used this way. You would see a window popup then dissapear. This is a tool that is meant to be run from the command line.
+
+Navigate to the directory of the game's pak files. This will be located at `game install path/game name/game project name/Content/Paks/`. Then open a command prompt shell. You can do that easily by either right clicking anywhere on the file explorer and clicking "Open in Terminal/command prompt", or by clicking on the file path bar (where it says `game > Content > Paks`), typing `cmd` and hitting enter.
+
+In your cmd window, type `repak -h`. This should list the help menu for repak. 
+
+> [!CAUTION]
+> If you get an error like "command repak not found", you did not install repak correctly. If you opened the cmd before installing repak, you must close and re-open cmd.
+
+To view the unpack command options, simply run `repak unpack -h`.
+
+Unpacking is simple, just follow the help menu.
+
+> [!WARNING]
+> If your game has an AES key (i.e. is encrypted), you can find it in the [Adding AES](AesKey.md) guide, then use the `--aes-key` option in your unpack command.
+
+#### Example unpack commands:
+
+`repak unpack MyGameName-WindowsNoEditor.pak`
+
+`repak unpack MyGameName-WindowsNoEditor.pak --output "F:/Modding/Game/Unpacked"`
+
+`repak --aes-key 0x12345678 unpack MyEncryptedGame.pak`
+
+#### Pakchunks
+
+If your game uses pakchunks (many smaller `.pak` files instead of one big one), you have to do a tiny bit more work. Repak can only process one pak at a time, so you can't just have some wildcard to unpak all pak files in a directory.
+
+To unpack them all at once, do the following:
+1. Open powershell (by similar way as above, such as typing `pwsh` into file path box)
+2. Use your normal command, but instead of specifying your specific `.pak` file, you can type `repak unpack (gci *.pak)`
+
+> [!TIP]
+> If you want to output all files into the same folder, specify your output folder with `--output`. Alternately, if you want each pak file to have its own unpacked folder, do not specify the `--output` option.
+
+E.g.
+
+`repak --aes-key 0x12345678 unpack (gci *.pak) --output "F:/Modding/Game/Unpacked"`

--- a/TheBasics/ExtractingCooked.md
+++ b/TheBasics/ExtractingCooked.md
@@ -2,7 +2,7 @@
 > [!IMPORTANT]
 > This only guide applies when there are NOT `.ucas` or `.utoc` files inside `Content/Paks` folder. There may be `.pak`, `.sig` or other files or folders.   
 
-## Repak
+## repak
 
 For this guide, we will be using [repak](https://github.com/trumank/repak). This tool is widely used as it:
 1. Is very easy to download and use
@@ -52,9 +52,11 @@ Unpacking is simple, just follow the help menu.
 
 #### Pakchunks
 
-If your game uses pakchunks (many smaller `.pak` files instead of one big one), you have to do a tiny bit more work. Repak can only process one pak at a time, so you can't just have some wildcard to unpak all pak files in a directory.
+If the game uses pakchunks (many smaller `.pak` files instead of one big one), Windows users have to do tiny bit more work.
 
-To unpack them all at once, do the following:
+If you are on Linux, you can simply use the `*.pak` wildcard.
+
+If you are on Windows, to unpack them all at once, do the following:
 1. Open powershell (by similar way as above, such as typing `pwsh` into file path box)
 2. Use your normal command, but instead of specifying your specific `.pak` file, you can type `repak unpack (gci *.pak)`
 

--- a/TheBasics/ExtractingIoStore.md
+++ b/TheBasics/ExtractingIoStore.md
@@ -1,0 +1,78 @@
+# Extracting IoStore Cooked Assets
+> [!IMPORTANT]
+> This only guide applies when there are `.ucas`, `.utoc` & `.pak` files inside `Content/Paks` folder.
+
+> [!CAUTION]
+> [FModel](UsingFModel.md) can open `IoStore` containers/paks, and can even let you export them. However, these assets are in a format that only allows them to be read-only. This means that these assets cannot be edited in a valid way for modding (e.g. with [UAssetGUI](../BasicModding/UAssetGUI.md)), nor can they be repackaged.
+
+## ZenTools
+
+ZenTools is a tool that extracts the traditional cooked assets (`.uasset`/`.uexp`) from the `IoStore` container files, which are `.ucas`, `.utoc` & `.pak`. Because some tools out there only support the traditional cooked asset format, such as [UAssetGUI](../BasicModding/UAssetGUI.md), you need to get the right format of assets first.
+
+There are two versions of ZenTools that you need to get depending on your game's UE version; 
+- [ZenTools for UE5](https://github.com/LongerWarrior/ZenTools/tree/5.1-5.2) (if your game is UE5)
+- [ZenTools for UE4](https://github.com/WistfulHopes/ZenTools-UE4) (obviously if your game is UE4)
+
+### ZenTools for UE5
+
+Go to the [release page](https://github.com/LongerWarrior/ZenTools/releases) and download the latest release. This can just be the `ZenTools.exe` file, but you may also want to download the `.pdb` file alongside it in-case you have errors and want to post the tool output (this is useful for the maintianer).
+
+> [!WARNING]
+> Do not run `ZenTools.exe` by clicking on it, it is not meant to be used this way. You would see a window popup then dissapear. This is a tool that is meant to be run from the command line.
+
+Navigate to your modding directory of choice. Then open a command prompt shell. You can do that easily by either right clicking anywhere on the file explorer and clicking "Open in Terminal/command prompt", or by clicking on the file path bar (`folder > folder > folder`), typing `cmd` and hitting enter.
+
+Simply follow the [usage guide](https://github.com/LongerWarrior/ZenTools/tree/5.1-5.2?tab=readme-ov-file#usage) in the project's README on GitHub and enter your command into cmd.
+
+> [!IMPORTANT]
+> If your game is UE5.1, make sure to include the `-ZenPackageVersion=Initial` option in your command.
+> If your game has an AES key (i.e. is encrypted), you can find it in the [Adding AES](AesKey.md) guide, then use the `-AES=` option in your command.
+
+> [!TIP]
+> Make sure to use quotation marks `""` whenever you are specifying file paths if they contain any spaces.
+
+#### Example commands
+
+If your game is UE5.1: 
+
+`ZenTools.exe ExtractPackages "Path to UE5.1 game/Content/Paks" "Output directory" -ZenPackageVersion=Initial`
+
+If your game is UE5.1 and has encryption:
+
+`ZenTools.exe ExtractPackages "Path to UE5.1 game/Content/Paks" "Output directory" -ZenPackageVersion=Initial -AES=0x12345678`
+
+If your game is UE5.2 amd has encryption:
+
+`ZenTools.exe ExtractPackages "Path to UE5.2 game/Content/Paks" "Output directory" -AES=0x12345678`
+
+#### Repacking UE5 IoStore files
+
+Follow this guide
+
+### ZenTools for UE4
+
+Install ZenTools UE4 in the same way as ZenTools UE5 - [download link](https://github.com/WistfulHopes/ZenTools-UE4/releases).
+
+If your game is encrypted, note that there is no `-Aes=` or equivalent option, you must supply a `keys.json` file. This is simply a file that is:
+```json
+{
+    "00000000-0000-0000-0000-000000000000": "DEADBEEFCAFEDEADBEEFCAFEDEADBEEFCAFEDEADBEEFCAFEDEADBEEFCAFEDEAD"
+}
+```
+
+> [!WARNING]
+> The keys.json does not support `0x` at the start of your AES key, so make sure to remove that in the file.
+
+#### Example commands
+
+If game has encryption:
+
+`ZenTools.exe ExtractPackages "Path to UE4 game/Content/Paks" "Output directory" -EncryptionKeys="Path to keys.json"`
+
+If game has no encryption:
+
+`ZenTools.exe ExtractPackages "Path to UE4 game/Content/Paks" "Output directory"`
+
+#### Repacking UE4 IoStore files
+
+Follow this guide

--- a/TheBasics/ExtractingIoStore.md
+++ b/TheBasics/ExtractingIoStore.md
@@ -1,9 +1,9 @@
 # Extracting IoStore Cooked Assets
 > [!IMPORTANT]
-> This only guide applies when there are `.ucas`, `.utoc` & `.pak` files inside `Content/Paks` folder.
+> This guide only applies when there are `.ucas`, `.utoc` & `.pak` files inside `Content/Paks` folder.
 
 > [!CAUTION]
-> [FModel](UsingFModel.md) can open `IoStore` containers/paks, and can even let you export them. However, these assets are in a format that only allows them to be read-only. This means that these assets cannot be edited in a valid way for modding (e.g. with [UAssetGUI](../BasicModding/UAssetGUI.md)), nor can they be repackaged.
+> [FModel](UsingFModel.md) can open `IoStore` containers/paks, and can even let you export them. However, these assets are in a format are incompatible with [UAssetGUI](../BasicModding/UAssetGUI.md), but can be edited by manual [hex editing](../BasicModding/HexEditing.md). 
 
 ## ZenTools
 
@@ -28,8 +28,11 @@ Simply follow the [usage guide](https://github.com/LongerWarrior/ZenTools/tree/5
 > If your game is UE5.1, make sure to include the `-ZenPackageVersion=Initial` option in your command.
 > If your game has an AES key (i.e. is encrypted), you can find it in the [Adding AES](AesKey.md) guide, then use the `-AES=` option in your command.
 
-> [!TIP]
+> [!CAUTION]
 > Make sure to use quotation marks `""` whenever you are specifying file paths if they contain any spaces.
+
+> [!TIP]
+> If it is taking a long time to extract, try using package filters to filter certain folders, for example `/Game/Content/Blueprints`. You can find project folders by opening the pak in FModel
 
 #### Example commands
 
@@ -41,13 +44,17 @@ If your game is UE5.1 and has encryption:
 
 `ZenTools.exe ExtractPackages "Path to UE5.1 game/Content/Paks" "Output directory" -ZenPackageVersion=Initial -AES=0x12345678`
 
-If your game is UE5.2 amd has encryption:
+If your game is UE5.2 and has encryption:
 
 `ZenTools.exe ExtractPackages "Path to UE5.2 game/Content/Paks" "Output directory" -AES=0x12345678`
 
+If your game is very large (e.g. 100GB+) and you want to only extract certain asset paths, say, weapon blueprints folder:
+
+`ZenTools.exe ExtractPackages "Path to game/Content/Paks" "Output directory" -PackageFilter=/Game/Content/Blueprints/Weapons`
+
 #### Repacking UE5 IoStore files
 
-Follow this guide
+Follow [this guide](../BasicModding/IoStorePacking.md#scenario-1-packing-cooked-assets).
 
 ### ZenTools for UE4
 
@@ -60,8 +67,14 @@ If your game is encrypted, note that there is no `-Aes=` or equivalent option, y
 }
 ```
 
-> [!WARNING]
+> [!CAUTION]
 > The keys.json does not support `0x` at the start of your AES key, so make sure to remove that in the file.
+
+> [!CAUTION]
+> Make sure to use quotation marks `""` whenever you are specifying file paths if they contain any spaces.
+
+> [!TIP]
+> If it is taking a long time to extract, try using package filters to filter certain folders, for example `/Game/Content/Blueprints`. You can find project folders by opening the pak in FModel
 
 #### Example commands
 
@@ -73,6 +86,10 @@ If game has no encryption:
 
 `ZenTools.exe ExtractPackages "Path to UE4 game/Content/Paks" "Output directory"`
 
+If your game is very large (e.g. 100GB+) and you want to only extract certain asset paths, say, enemy blueprints folder:
+
+`ZenTools.exe ExtractPackages "Path to game/Content/Paks" "Output directory" -PackageFilter=/Game/Content/Blueprints/Enemies`
+
 #### Repacking UE4 IoStore files
 
-Follow this guide
+Follow [this guide](../BasicModding/IoStorePacking.md#scenario-1-packing-cooked-assets).


### PR DESCRIPTION
Haven't used any images, perhaps some should be added where necessary, but I'm not sure. 

IoStorePacking.md guide is a bit lackluster, I'm not particularly experienced with it and would love some input from someone who has to write better sections for it, especially for UE4 section, which also needs a tuw tool for it really to be any good. 

And the FModel zen assets section is lacking, currently I have a link to UnrealReZen, as I have no experience with it.